### PR TITLE
Updating README with new travis URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# Zebra [![Build Status](https://travis-ci.org/joshmobley/zebra.png?branch=master)](https://travis-ci.org/joshmobley/zebra)
+# Clearer [![Build Status](https://travis-ci.org/joshmobley/clearer.svg?branch=master)](https://travis-ci.org/joshmobley/clearer)
 


### PR DESCRIPTION
Current README is displaying a badge for zebra on Travis which doesn't exist anymore. Let me know if you want anything else in this body of work.